### PR TITLE
Add support and recommendation for the state param [CSRF protection]

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,13 +39,27 @@ This will automatically have your client authenticate with HomeAway. If you wish
 client.auth_url
 ```
 
-which will return back a URL as a String that the user of your application must be sent to. It is up to you to define how that takes place. Once your user goes to that url they will prompted to login with their HomeAway credentials. As soon as they do that and authorize your application to access their HomeAway data, the client's web browser will be redirected back to the redirect url that you specified when you created your client above. This url will have a code appended to it as a parameter named code. Once you are able to grab that code, you can use it with this gem:
+which will return back a URL as a String that the user of your application must be sent to. It is up to you to define how that takes place.
+
+_Note: You are recommended to save the `client.state` value. It is used to prevent your application from CSRF attacks ([http://homakov.blogspot.pt/2012/07/saferweb-most-common-oauth2.html](more details)). Saving it in the session is one way to achieve this, you will need to access this value again once the user is redirected back to your application and to ensure it's identicity with the one given then._
+
+Example with a RubyOnRails controller:
+
+```ruby
+session["homeaway-api.state"] = client.state
+```
+
+Once your user goes to that url they will be prompted to login with their HomeAway credentials. As soon as they do that and authorize your application to access their HomeAway data, the client's web browser will be redirected back to the redirect url that you specified when you created your client above. This url will have the `code` and `state` parameters appended to it.
+
+It's now time to ensure that this `state` parameter is present and identical to the previously saved `state` value. If this value have changed, it as then been tempered and certainly the reason of a CSRF attack, and should not perform the next step.
+
+Once the `state` validated and you are able to grab that code, you can use it with this gem:
 
 ```ruby
 client.oauth_code = code_received_from_redirect_url
 ```
 
-As soon as you make that assignment, the client will contact HomeAway and obtain a token that can be used for interacting with the HomeAway for that user for that particular session. By default, this token has a 6 month expiration time.
+As soon as you make that assignment, the client will contact HomeAway and obtain a token that can be used for interacting with the HomeAway account of that user. By default, this token has a 6 month expiration time.
 
 ### Using an existing token
 

--- a/lib/homeaway/api/util/oauth.rb
+++ b/lib/homeaway/api/util/oauth.rb
@@ -25,9 +25,16 @@ module HomeAway
           Base64.strict_encode64 "#{@configuration.client_id}:#{@configuration.client_secret}"
         end
 
-        # @private
+        # @return [String] the authorization URL you need to redirect a HomeAway user
+        #                  to grant you access to their account.
         def auth_url
-          oauth_client_strategy.authorize_url
+          oauth_client_strategy.authorize_url(state: state)
+        end
+
+        # @return [String] a 48 characters long, securely random string, used to mitigate
+        #                  CSRF attacks during the authorization process.
+        def state
+          @_state ||= SecureRandom.hex(24)
         end
 
         # completes the oauth flow

--- a/spec/oauth_spec.rb
+++ b/spec/oauth_spec.rb
@@ -47,6 +47,11 @@ describe 'oauth', :vcr do
     expect(@client.token).to_not be_nil
   end
 
+  it 'gets back the proper state when following the oauth flow' do
+    expect(@client).to receive(:state).and_return("SECURE_RANDOM_STRING")
+    expect(get_state).to eql "SECURE_RANDOM_STRING"
+  end
+
   it 'can auth with only 2 legs' do
     expect {
       expect(@client.listing('100000')).to_not be_nil

--- a/spec/oauth_spec.rb
+++ b/spec/oauth_spec.rb
@@ -21,8 +21,22 @@ describe 'oauth', :vcr do
     @client = scaffolded_client
   end
 
-  it 'has a proper authorize url' do
-    expect(@client.auth_url).to include '/oauth/authorize'
+  describe '#auth_url' do
+    it 'has a proper authorize url' do
+      expect(@client.auth_url).to include '/oauth/authorize'
+    end
+
+    it 'includes the state parameter' do
+      expect(@client).to receive(:state).and_return("SECURE_RANDOM_STRING")
+      expect(@client.auth_url).to include 'state=SECURE_RANDOM_STRING'
+    end
+  end
+
+  describe '#state' do
+    it 'generates a secure random string' do
+      expect(SecureRandom).to receive(:hex).with(24).and_return("SECURE_RANDOM_STRING")
+      expect(@client.state).to eq "SECURE_RANDOM_STRING"
+    end
   end
 
   it 'can go with the oauth flow' do


### PR DESCRIPTION
Inspired by the implementation of [omniauth-oauth2](https://github.com/intridea/omniauth-oauth2/blob/master/lib/omniauth/strategies/oauth2.rb#L51) and driven by the CSRF security concerns raised by [Egor Homakov](http://homakov.blogspot.pt/2012/07/saferweb-most-common-oauth2.html) from [Sakurity.com](http://sakurity.com/) this adds support for the `state` param and update the documentation to recommend it's usage.
